### PR TITLE
move config to its own file

### DIFF
--- a/adam-script.py
+++ b/adam-script.py
@@ -167,12 +167,6 @@ def get_marks_file_path():
 
 
 # Miscellaneous ----------------------------------------------------------------
-def is_email(email: str) -> bool:
-    """
-    Check if a string more or less matches the format of an email address.
-    """
-    return type(email) is str and bool(re.match(r"[^@]+@[^@]+\.[^@]+", email))
-
 
 def is_hidden_file(name: str) -> bool:
     """

--- a/config.py
+++ b/config.py
@@ -1,0 +1,190 @@
+import json
+import logging
+from pathlib import Path
+import re
+import types
+from typing import Union, Callable, get_origin, get_args
+
+Student = tuple[str, str, str]
+Team = list[Student]
+
+def ensure_list(value):
+    if not value:
+        return []
+    elif isinstance(value, list):
+        return value
+    else:
+        return [value]
+
+_the_config = None
+
+def load(*config_paths: list[Path]) -> None:
+    global _the_config
+    _the_config = Config(config_paths)
+
+def get():
+    global _the_config
+    if _the_config is None:
+        logging.critical("Accessed config before loading it.")
+    return _the_config
+
+class Config:
+    def __init__(self, config_paths: list[Path]) -> None:
+        data = {}
+        for path in config_paths:
+            logging.info(f"Reading config file '{path}'")
+            data.update(json.loads(path.read_text(encoding="utf-8")))
+
+        self._extract_value(data, "tutor_name", str),
+        self._extract_value(data, "ignore_feedback_suffix", list[str], 
+            _validate_elements(_validate_suffix), optional=True, default=[]),
+
+            # Email settings, currently all optional because not fully functional.
+        self._extract_value(data, "tutor_email", str,
+            _validate_email, optional=True),
+        self._extract_value(data, "assistant_email", str,
+            _validate_email, optional=True),
+        self._extract_value(data, "feedback_email_cc", list[str], 
+            _validate_elements(_validate_email), optional=True, default=[]),
+        self._extract_value(data, "smtp_url", str, optional=True),
+        self._extract_value(data, "smtp_port", int, optional=True),
+        self._extract_value(data, "smtp_user", str, optional=True),
+
+        self._extract_value(data, "lecture_title", str, _validate_non_empty),
+        self._extract_value(data, "marking_mode", str,
+            _validate_choices("static", "random", "exercise")),
+
+        self._extract_value(data, "max_team_size", int, _validate_positive),
+        self._extract_value(data, "use_marks_file", bool),
+        self._extract_value(data, "points_per", str,
+            _validate_choices("sheet", "exercise")),
+        self._extract_value(data, "min_point_unit", Union[float, int],
+            _validate_positive),
+
+
+        # We currently plan to support the following marking modes.
+        # static:   Every tutor corrects the submissions of the teams assigned to
+        #           that tutor. These will usually be the teams in that tutors
+        #           exercise class.
+        # random:   Every tutor corrects some submissions which are assigned
+        #           randomly with every sheet.
+        # exercise: Every tutor corrects some exercise(s) on all sheets.
+        if self.marking_mode == "static":
+            self._extract_value(data, "classes", dict[str, list[Team]])
+            if self.tutor_name not in self.classes:
+                logging.critical(f"Did not find a class for '{self.tutor_name}' in the config.")
+            self.teams = [team for classs in self.classes.values() for team in classs]
+        else:
+            self._extract_value(data, "tutor_list", list[str])
+            if self.tutor_name not in self.tutor_list:
+                logging.critical(f"Did not find '{self.tutor_name}' in tutor_list in the config.")
+            self._extract_value(data, "teams", list[Team])
+
+        _validate_teams(self.teams, self.max_team_size)
+        # Sort teams and their students to make iterating over them
+        # predictable, independent of their order in config.json.
+        for team in self.teams:
+            team.sort()
+        self.teams.sort()
+        logging.info("Processed config successfully.")
+
+    def _extract_value(self, data, key, expected_type, validators=None, optional=False, default=None):
+        if not optional and key not in data:
+            logging.critical(f"Expected option '{key}' to be configured but "
+                             "did not find it in any config file.")
+        value = data.get(key, default)
+        _validate_expected_type(key, value, expected_type)
+        for validator in ensure_list(validators):
+            validator(key, value)
+        setattr(self, key, value)
+
+def _validate_expected_type(key: str, value: str, expected_type: type) -> None:
+    if isinstance(expected_type, types.GenericAlias):
+        if get_origin(expected_type) == list:
+            if not isinstance(value, list):
+                logging.critical(f"Expected option '{key}' to be a list but "
+                                f"got '{type(value).__name__}'.")
+            element_type = get_args(expected_type)[0]
+            for i, element in enumerate(value):
+                _validate_expected_type(f"{key}[{i}]", element, element_type)
+        elif get_origin(expected_type) == dict:
+            if not isinstance(value, dict):
+                logging.critical(f"Expected option '{key}' to be a dict but "
+                                f"got '{type(value).__name__}'.")
+            key_type = get_args(expected_type)[0]
+            value_type = get_args(expected_type)[1]
+            for i, (d_key, d_value) in enumerate(value.items()):
+                _validate_expected_type(f"Key {i} of {key}", d_key, key_type)
+                _validate_expected_type(f"{key}[{d_key}]", d_value, value_type)
+        elif get_origin(expected_type) == tuple:
+            if not (isinstance(value, list) or isinstance(value, tuple)):
+                logging.critical(f"Expected option '{key}' to be a tuple but "
+                                f"got '{type(value).__name__}'.")
+            elmenent_types = get_args(expected_type)
+            if len(value) != len(elmenent_types):
+                logging.critical(f"Expected option '{key}' to be a tuple of "
+                                    f"length {len(elmenent_types)} but got a tuple of "
+                                    f"length {len(value)}.")
+            for i, (element, elmenent_type) in enumerate(zip(value, elmenent_types)):
+                _validate_expected_type(f"Element {i} of {key}", element, elmenent_type)
+        else:
+            logging.critical("Unsupported Generic type")
+    elif not isinstance(value, expected_type):
+        logging.critical(f"Expected option '{key}' to be "
+                        f"'{expected_type.__name__}' but "
+                        f"got '{type(value).__name__}'.")
+
+
+def _validate_email(key: str, value: str) -> None:
+    if not re.match(r"[^@]+@[^@]+\.[^@]+", value):
+        logging.critical(f"Value '{value}' for option '{key}' does not match "
+                         "the format of an email address.")
+
+
+def _validate_suffix(key: str, value: str) -> None:
+    if not (value.startswith(".") and len(value) > 1):
+        logging.critical(f"Value '{value}' for option '{key}' does not match "
+                         "the format of a suffix (e.g. '.xopp').")
+
+
+def _validate_elements(element_validator) -> Callable[[list], None]:
+    def validator(key: str, value: list) -> bool:
+        for i, element in enumerate(value):
+            return element_validator(f"{key}[{i}]", element)
+    return validator
+
+
+def _validate_non_empty(key: str, value: str) -> bool:
+    if not value:
+        logging.critical(f"Expected nonempty value for option '{key}'.")
+
+
+def _validate_choices(*choices: list[str]) -> Callable[[str], bool]:
+    def validator(key: str, value: str) -> bool:
+        if value.lower() not in [c.lower() for c in choices]:
+            logging.critical(f"Value '{value}' for option '{key}' must be one "
+                             f"of {{{', '.join(choices)}}}.")
+    return validator
+
+
+def _validate_positive(key: str, value: Union[int, float]) -> bool:
+    if value <= 0:
+        logging.critical(f"Expected positive value for option '{key}' but got '{value}'.")
+
+def _validate_teams(teams: list[Team], max_team_size) -> None:
+    """
+    Check for duplicate entries and maximal team size.
+    """
+    all_students: list[tuple[str, str]] = []
+    all_emails: list[str] = []
+    for team in teams:
+        if  len(team) > max_team_size:
+            logging.critical(f"Team with size {len(team)} violates maximal team size.")
+        for first, last, email in team:
+            _validate_email("Email of {first} {last}", email)
+            all_students.append((first, last))
+            all_emails.append(email)
+    if len(all_students) != len(set(all_students)):
+        logging.critical("There are duplicate students in the config file!")
+    if len(all_emails) != len(set(all_emails)):
+        logging.critical("There are duplicate student emails in the config file!")

--- a/tests/config-individual.json
+++ b/tests/config-individual.json
@@ -1,9 +1,9 @@
 {
-    "your_name": "PLACEHOLDER_NAME",
-    "your_email": "tatiana.tutor@unibas.ch",
+    "tutor_name": "add your name here matching the shared config",
+    "tutor_email": "your.email@unibas.ch",
     "feedback_email_cc": [ "tamara.tutor@unibas.ch", "tatiana.tutor@unibas.ch", "terence.tutor@unibas.ch" ],
-    "smtp_url": "smtp-ext.unibas.ch",
-    "smtp_port": 587,
-    "smtp_user": "tuttat00",
+    "smtp_url": "smtp.unibas.ch",
+    "smtp_port": 25,
+    "smtp_user": "",
     "ignore_feedback_suffix": [ ".xopp" ]
 }

--- a/tests/config-shared-exercise.json
+++ b/tests/config-shared-exercise.json
@@ -2,7 +2,7 @@
     "lecture_title": "Foundations of Artificial Intelligence",
     "assistant_email": "florian.pommerening@unibas.ch",
     "marking_mode": "exercise",
-    "use_marks_file": "True",
+    "use_marks_file": true,
     "points_per": "exercise",
     "min_point_unit": 0.5,
     "tutor_list": [ "tamara", "tatiana", "terence" ],

--- a/tests/config-shared-random.json
+++ b/tests/config-shared-random.json
@@ -2,7 +2,7 @@
     "lecture_title": "Foundations of Artificial Intelligence",
     "assistant_email": "florian.pommerening@unibas.ch",
     "marking_mode": "random",
-    "use_marks_file": "True",
+    "use_marks_file": true,
     "points_per": "exercise",
     "min_point_unit": 0.5,
     "tutor_list": [ "tamara", "tatiana", "terence" ],

--- a/tests/config-shared-static.json
+++ b/tests/config-shared-static.json
@@ -2,11 +2,11 @@
     "lecture_title": "Foundations of Artificial Intelligence",
     "assistant_email": "florian.pommerening@unibas.ch",
     "marking_mode": "static",
-    "use_marks_file": "True",
+    "use_marks_file": true,
     "points_per": "sheet",
     "min_point_unit": 0.5,
     "max_team_size": 3,
-    "teams": {
+    "classes": {
         "tamara": [
             [
                 ["Sabine", "Sommer", "sabine.sommer@stud.unibas.ch"]


### PR DESCRIPTION
I started with separating config (stuff that comes from the configuration files) from arguments (stuff that depends on the command line call). Next, I'll try to also separate arguments and sheet info (stuff that is stored in `.sheet_info`).

Some things changed in addition to the separation:
* `use_marks_file` is now a boolean in json, not a `"true"/"false"` string
* `your_name` and `your_email` is now `tutor_name` and `tutor_email`. Previously it had a different name internally (in `args`) and externally (in the json file), which I found confusing.
* `teams` can no longer have two different formats depending on the marking mode. Instead, we either specify `classes` or `teams` in the config and generate `teams` from `classes` if needed. Before, the value of `teams` sometimes ended up in `args.classes` while `args.teams` was generated from it and did not match the json file.
* shared and individual config files are now treated differently: before they had to contain certain keys each and could not overlap. now, they are merged before parsing. This means that we can specify any options in the shared config and the individual config can override any option. For example, we can specify the default smtp server in the shared config and if a tutor uses a different one, they can set it in their individual config.